### PR TITLE
Exclude compilation of hypot function already defined in C++17

### DIFF
--- a/src/tools/MathToolbox.cpp
+++ b/src/tools/MathToolbox.cpp
@@ -13,6 +13,8 @@
 const double NaN_double = std::numeric_limits<double>::quiet_NaN();
 //const float NaN = std::numeric_limits<float>::quiet_NaN();
 
+#if __cplusplus < 201703L
+
 /**
  * Berechne die Laenge der Hypothenuse
  */
@@ -21,6 +23,7 @@ double hypot(double x, double y, double z)
 	return sqrt(x*x + y*y + z*z);
 }
 
+#endif  // C++17
 
 /**
  * Normalizes an angle given in radians by adding or subtracting an integer

--- a/src/tools/MathToolbox.hpp
+++ b/src/tools/MathToolbox.hpp
@@ -13,8 +13,9 @@
 #include <cmath>	// for abs()
 #include "../BasicDatatypes.hpp"
 
-
+#if __cplusplus < 201703L
 extern double hypot(double x, double y, double z);
+#endif  // C++17
 
 /// Not-a-Number in double precision
 extern const double NaN_double;


### PR DESCRIPTION
The hypot function defined in MathToolbox.cpp conflicts with the same function from C++17, so I've added conditional compilation block so it is compiled only for C++ < 17. See https://en.cppreference.com/w/cpp/numeric/math/hypot